### PR TITLE
CVE-2018-11784

### DIFF
--- a/java/org/apache/catalina/servlets/DefaultServlet.java
+++ b/java/org/apache/catalina/servlets/DefaultServlet.java
@@ -1037,6 +1037,10 @@ public class DefaultServlet
             location.append('?');
             location.append(request.getQueryString());
         }
+        // Avoid protocol relative redirects
+        while (location.length() > 1 && location.charAt(1) == '/') {
+            location.deleteCharAt(0);
+        }
         response.sendRedirect(response.encodeRedirectURL(location.toString()));
     }
 

--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -76,6 +76,10 @@
         of the CGI servlet from <code>true</code> to <code>false</code> as
         additional hardening against CVE-2019-0232. (markt)
       </update>
+      <fix>
+        When generating a redirect to a directory in the Default Servlet, avoid
+        generating a protocol relative redirect. (markt)
+      </fix>
     </changelog>
   </subsection>
 </section>


### PR DESCRIPTION
When generating a redirect to a directory in the Default Servlet, avoid generating a protocol relative redirect. git-svn-id: https://svn.apache.org/repos/asf/tomcat/tc7.0.x/trunk@1840057 13f79535-47bb-0310-9956-ffa450edef68