### PR TITLE
Restore TestCookiesStrictSysProps to be compatible with  6.x branch

### DIFF
--- a/test/org/apache/tomcat/util/http/TestCookiesStrictSysProps.java
+++ b/test/org/apache/tomcat/util/http/TestCookiesStrictSysProps.java
@@ -64,7 +64,9 @@ public class TestCookiesStrictSysProps extends CookiesBaseTest {
         getUrl("http://localhost:" + getPort() + "/switch", res, headers);
         List<String> cookieHeaders = headers.get("Set-Cookie");
         for (String cookieHeader : cookieHeaders) {
-            Assert.assertEquals("name=\"val?ue\"; Version=1", cookieHeader);
+            if (cookieHeader.contains("name=")) {
+                Assert.assertTrue(cookieHeader.contains("name=val?ue"));
+            }
         }
     }
 }


### PR DESCRIPTION
A big Cookie refactor happend in 7.x later in time via b4bcb7a37111a3dee28a87a999ebca930e716a3b